### PR TITLE
fix: argocd cli version

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -47,7 +47,7 @@ runs:
 
     - name: Install argocd cli
       run: |
-        curl -sSL -o argocd-linux-amd64 https://github.com/argoproj/argo-cd/releases/download/v2.5.3/argocd-linux-amd64
+        curl -sSL -o argocd-linux-amd64 https://github.com/argoproj/argo-cd/releases/download/v2.6.7/argocd-linux-amd64
         sudo install -m 555 argocd-linux-amd64 /usr/local/bin/argocd
       shell: bash
 


### PR DESCRIPTION
## Description

argocd server introduced a [breaking change in version 2.6.7](https://github.com/argoproj/argo-cd/releases/tag/v2.6.7) so the argocd cli also needs to be updated to version 2.6.7

You can update in your machine with (during the install step make sure its the right destination path so that you don't have multiple executables `which argocd`):
```bash
curl -sSL -o argocd-linux-amd64 https://github.com/argoproj/argo-cd/releases/download/v2.6.7/argocd-linux-amd64
sudo install -m 555 argocd-linux-amd64 /usr/local/bin/argocd
```


## Is this PR related with an open issue?

Related to Issue #

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Checklist:

- [ ] Follows the code style of this project.
- [ ] Tests Cover Changes
- [ ] Documentation

#### Funny gif

![Put a link of a funny gif inside the parenthesis-->]()